### PR TITLE
Create the visual version of Layout L004

### DIFF
--- a/src/components/layout/BoardSection/index.tsx
+++ b/src/components/layout/BoardSection/index.tsx
@@ -1,0 +1,41 @@
+import { Stack, Text, inube } from "@inube/design-system";
+
+import { StyledBoardSection, StyledDivider } from "./styles";
+import { SectionBackground } from "./types";
+
+interface IBoardSectionProps {
+  sectionTitle: string;
+  numberActiveCards: number;
+  sectionBackground: SectionBackground;
+  children: JSX.Element | JSX.Element[];
+}
+
+function BoardSection(props: IBoardSectionProps) {
+  const {
+    sectionTitle,
+    numberActiveCards,
+    sectionBackground = "light",
+    children,
+  } = props;
+  return (
+    <>
+      <StyledDivider />
+      <StyledBoardSection sectionBackground={sectionBackground}>
+        <Stack justifyContent="space-between" gap={inube.spacing.s200}>
+          <Text type="title" ellipsis>
+            {sectionTitle}
+          </Text>
+          <Text type="title" size="medium">
+            {numberActiveCards}
+          </Text>
+        </Stack>
+        <Stack direction="column" gap={inube.spacing.s200}>
+          {children}
+        </Stack>
+      </StyledBoardSection>
+    </>
+  );
+}
+
+export { BoardSection };
+export type { IBoardSectionProps };

--- a/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
+++ b/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
@@ -1,5 +1,6 @@
-import { Text } from "@inube/design-system";
 import { StoryFn, Meta } from "@storybook/react";
+
+import { SummaryCard } from "@components/cards/SummaryCard";
 
 import { BoardSection, IBoardSectionProps } from "..";
 import { props } from "./props";
@@ -14,26 +15,30 @@ export const Default: StoryFn<IBoardSectionProps> = (args) => (
   <BoardSection {...args} />
 );
 
+const SummaryCardInfo = {
+  rad: 100000012,
+  date: "Septiembre 30/23",
+  name: "Juan Sebastian Moralez García",
+  destination: "Educación de Postgrado a menos de tres meses",
+  value: 10000000,
+  toDo: "Aceptación por parte del cliente de la propuesta",
+  isPinned: true,
+  hasMessage: true,
+};
+
 const EmptyCards = () => (
   <>
-    <Text type="title" appearance="gray">
-      SummaryCard
-    </Text>
-    <Text type="title" appearance="gray">
-      SummaryCard
-    </Text>
-    <Text type="title" appearance="gray">
-      SummaryCard
-    </Text>
-    <Text type="title" appearance="gray">
-      SummaryCard
-    </Text>
+    <SummaryCard {...SummaryCardInfo}></SummaryCard>
+    <SummaryCard {...SummaryCardInfo}></SummaryCard>
+    <SummaryCard {...SummaryCardInfo}></SummaryCard>
+    <SummaryCard {...SummaryCardInfo}></SummaryCard>
+    <SummaryCard {...SummaryCardInfo}></SummaryCard>
   </>
 );
 
 Default.args = {
   sectionTitle: "BoardSectionTitle",
-  numberActiveCards: 4,
+  numberActiveCards: 5,
   children: <EmptyCards />,
   sectionBackground: "gray",
 };

--- a/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
+++ b/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
@@ -1,0 +1,41 @@
+import { Text } from "@inube/design-system";
+import { StoryFn, Meta } from "@storybook/react";
+
+import { BoardSection, IBoardSectionProps } from "..";
+import { props } from "./props";
+
+const story: Meta<typeof BoardSection> = {
+  component: BoardSection,
+  argTypes: props,
+  title: "layouts/BoardSection",
+};
+
+export const Default: StoryFn<IBoardSectionProps> = (args) => (
+  <BoardSection {...args} />
+);
+
+const EmptyCards = () => (
+  <>
+    <Text type="title" appearance="gray">
+      SummaryCard
+    </Text>
+    <Text type="title" appearance="gray">
+      SummaryCard
+    </Text>
+    <Text type="title" appearance="gray">
+      SummaryCard
+    </Text>
+    <Text type="title" appearance="gray">
+      SummaryCard
+    </Text>
+  </>
+);
+
+Default.args = {
+  sectionTitle: "BoardSectionTitle",
+  numberActiveCards: 4,
+  children: <EmptyCards />,
+  sectionBackground: "gray",
+};
+
+export default story;

--- a/src/components/layout/BoardSection/stories/props.ts
+++ b/src/components/layout/BoardSection/stories/props.ts
@@ -1,0 +1,23 @@
+const props = {
+  sectionTitle: {
+    control: "text",
+    description: "Section title",
+  },
+  numberActiveCards: {
+    control: "number",
+    description: "Number of active cards in the section",
+  },
+  sectionBackground: {
+    control: {
+      type: "select",
+      options: ["gray", "light"],
+    },
+    description: "Section background",
+  },
+  children: {
+    control: "object",
+    description: "Child elements of the component",
+  },
+};
+
+export { props };

--- a/src/components/layout/BoardSection/styles.ts
+++ b/src/components/layout/BoardSection/styles.ts
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+import { inube } from "@inube/design-system";
+
+import { SectionBackground } from "./types";
+
+interface IStyledBoardSection {
+  theme?: typeof inube;
+  sectionBackground?: SectionBackground;
+}
+
+const StyledBoardSection = styled.div<IStyledBoardSection>`
+  display: flex;
+  flex-direction: column;
+  gap: ${inube.spacing.s150};
+  padding: ${inube.spacing.s400} ${inube.spacing.s150};
+  width: 261px;
+  height: 1500px;
+  background-color: ${({ theme, sectionBackground }) =>
+    sectionBackground === "gray"
+      ? theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular
+      : theme?.color?.surface?.light?.regular ||
+        inube.color.surface.light.regular};
+`;
+
+const StyledDivider = styled.hr`
+  margin: ${inube.spacing.s0};
+  width: 285px;
+  border: none;
+  border-top: 1px solid;
+  border-top-color: ${({ theme }: IStyledBoardSection) =>
+    theme?.color?.stroke?.divider?.dark || inube.color.stroke.divider.dark};
+`;
+
+export { StyledBoardSection, StyledDivider };

--- a/src/components/layout/BoardSection/types.ts
+++ b/src/components/layout/BoardSection/types.ts
@@ -1,0 +1,3 @@
+type SectionBackground = "gray" | "light";
+
+export type { SectionBackground };


### PR DESCRIPTION
The layout did not include functionality.

Empty cards were rendered.

The storybook was created.

In the task Include the visual version of Layout L005 CB-9 this same component will be modified so that it can be handled horizontally as required in the designs where I plan to handle a prop that tells the component if it is being handled horizontally or vertical.

![image](https://github.com/selsa-inube/crediboard/assets/87447257/082743bf-d872-49dc-b54c-6b6a9fc1e4d4)

A children was handled for the moment so that later in the task Include props of layout L004/L005 with number CB-10 the use of an array will be included where the information will be extracted to pass it to the SummaryCard C001 component, as well as configure the operation CU003 where the number of active cards is counted.