### PR TITLE
Include the visual version of Layout L005

### DIFF
--- a/src/components/cards/SummaryCard/styles.ts
+++ b/src/components/cards/SummaryCard/styles.ts
@@ -12,7 +12,7 @@ const StyledSummaryCard = styled.div`
   width: 260px;
   height: 270px;
   border-radius: 8px;
-  outline: 2px solid
+  outline: 1px solid
     ${({ theme }: IStyledSummaryCard) =>
       theme?.color?.stroke?.gray?.regular || inube.color.stroke.gray.regular};
   background-color: ${({ theme }: IStyledSummaryCard) =>

--- a/src/components/layout/BoardSection/index.tsx
+++ b/src/components/layout/BoardSection/index.tsx
@@ -1,12 +1,15 @@
-import { Stack, Text, inube } from "@inube/design-system";
+import { useState } from "react";
+import { Stack, Text, Icon, useMediaQuery, inube } from "@inube/design-system";
+import { MdOutlineChevronRight } from "react-icons/md";
 
-import { StyledBoardSection, StyledDivider } from "./styles";
-import { SectionBackground } from "./types";
+import { StyledBoardSection, StyledCollapseIcon } from "./styles";
+import { SectionBackground, SectionOrientation } from "./types";
 
 interface IBoardSectionProps {
   sectionTitle: string;
   numberActiveCards: number;
   sectionBackground: SectionBackground;
+  orientation: SectionOrientation;
   children: JSX.Element | JSX.Element[];
 }
 
@@ -15,25 +18,68 @@ function BoardSection(props: IBoardSectionProps) {
     sectionTitle,
     numberActiveCards,
     sectionBackground = "light",
+    orientation = "vertical",
     children,
   } = props;
+
+  const smallScreen = useMediaQuery("(max-width: 595px)");
+
+  const [collapse, setCollapse] = useState(true);
+
+  const handleCollapse = () => {
+    setCollapse(!collapse);
+  };
+
   return (
-    <>
-      <StyledDivider />
-      <StyledBoardSection sectionBackground={sectionBackground}>
-        <Stack justifyContent="space-between" gap={inube.spacing.s200}>
-          <Text type="title" ellipsis>
+    <StyledBoardSection
+      $sectionBackground={sectionBackground}
+      $orientation={orientation}
+    >
+      <Stack
+        justifyContent={
+          orientation === "vertical" ? "space-between" : "flex-start"
+        }
+        alignItems="center"
+        gap={inube.spacing.s300}
+      >
+        <Stack alignItems="center" gap={inube.spacing.s100}>
+          {orientation !== "vertical" && (
+            <StyledCollapseIcon $collapse={collapse} onClick={handleCollapse}>
+              <Icon
+                icon={<MdOutlineChevronRight />}
+                appearance="dark"
+                size="26px"
+                cursorHover
+              />
+            </StyledCollapseIcon>
+          )}
+          <Text
+            type={
+              orientation === "vertical" || smallScreen ? "title" : "headline"
+            }
+            size={
+              orientation === "vertical" || smallScreen ? "large" : "medium"
+            }
+            ellipsis
+          >
             {sectionTitle}
           </Text>
-          <Text type="title" size="medium">
-            {numberActiveCards}
-          </Text>
         </Stack>
-        <Stack direction="column" gap={inube.spacing.s200}>
+        <Text type="title" size="medium">
+          {numberActiveCards}
+        </Text>
+      </Stack>
+      {collapse && (
+        <Stack
+          wrap="wrap"
+          direction={orientation === "vertical" ? "column" : "row"}
+          justifyContent={smallScreen ? "center" : "flex-start"}
+          gap={inube.spacing.s250}
+        >
           {children}
         </Stack>
-      </StyledBoardSection>
-    </>
+      )}
+    </StyledBoardSection>
   );
 }
 

--- a/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
+++ b/src/components/layout/BoardSection/stories/BoardSection.stories.tsx
@@ -15,6 +15,10 @@ export const Default: StoryFn<IBoardSectionProps> = (args) => (
   <BoardSection {...args} />
 );
 
+export const Horizontal: StoryFn<IBoardSectionProps> = (args) => (
+  <BoardSection {...args} />
+);
+
 const SummaryCardInfo = {
   rad: 100000012,
   date: "Septiembre 30/23",
@@ -41,6 +45,12 @@ Default.args = {
   numberActiveCards: 5,
   children: <EmptyCards />,
   sectionBackground: "gray",
+  orientation: "vertical",
+};
+
+Horizontal.args = {
+  ...Default.args,
+  orientation: "horizontal",
 };
 
 export default story;

--- a/src/components/layout/BoardSection/stories/props.ts
+++ b/src/components/layout/BoardSection/stories/props.ts
@@ -14,6 +14,13 @@ const props = {
     },
     description: "Section background",
   },
+  orientation: {
+    control: {
+      type: "select",
+      options: ["vertical", "horizontal"],
+    },
+    description: "Section orientation",
+  },
   children: {
     control: "object",
     description: "Child elements of the component",

--- a/src/components/layout/BoardSection/styles.ts
+++ b/src/components/layout/BoardSection/styles.ts
@@ -1,34 +1,43 @@
 import styled from "styled-components";
 import { inube } from "@inube/design-system";
 
-import { SectionBackground } from "./types";
+import { SectionBackground, SectionOrientation } from "./types";
 
 interface IStyledBoardSection {
   theme?: typeof inube;
-  sectionBackground?: SectionBackground;
+  $sectionBackground?: SectionBackground;
+  $orientation?: SectionOrientation;
+}
+
+interface IStyledCollapseIcon {
+  $collapse: boolean;
 }
 
 const StyledBoardSection = styled.div<IStyledBoardSection>`
   display: flex;
   flex-direction: column;
   gap: ${inube.spacing.s150};
-  padding: ${inube.spacing.s400} ${inube.spacing.s150};
-  width: 261px;
-  height: 1500px;
-  background-color: ${({ theme, sectionBackground }) =>
-    sectionBackground === "gray"
+  padding: ${inube.spacing.s300} ${inube.spacing.s150} ${inube.spacing.s150};
+  width: ${({ $orientation }) =>
+    $orientation === "horizontal" ? "calc(100% - 24px)" : "261px"};
+  min-width: 261px;
+  height: ${({ $orientation }) =>
+    $orientation === "horizontal" ? "100%" : "1500px"};
+  border-top: 1px solid;
+  border-top-color: ${({ theme }: IStyledBoardSection) =>
+    theme?.color?.stroke?.divider?.dark || inube.color.stroke.divider.dark};
+  background-color: ${({ theme, $sectionBackground }) =>
+    $sectionBackground === "gray"
       ? theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular
       : theme?.color?.surface?.light?.regular ||
         inube.color.surface.light.regular};
 `;
 
-const StyledDivider = styled.hr`
-  margin: ${inube.spacing.s0};
-  width: 285px;
-  border: none;
-  border-top: 1px solid;
-  border-top-color: ${({ theme }: IStyledBoardSection) =>
-    theme?.color?.stroke?.divider?.dark || inube.color.stroke.divider.dark};
+const StyledCollapseIcon = styled.div<IStyledCollapseIcon>`
+  display: flex;
+  transition: all 500ms ease;
+  transform: ${({ $collapse }) =>
+    $collapse ? "rotate(-90deg)" : "rotate(90deg)"};
 `;
 
-export { StyledBoardSection, StyledDivider };
+export { StyledBoardSection, StyledCollapseIcon };

--- a/src/components/layout/BoardSection/styles.ts
+++ b/src/components/layout/BoardSection/styles.ts
@@ -37,7 +37,7 @@ const StyledCollapseIcon = styled.div<IStyledCollapseIcon>`
   display: flex;
   transition: all 500ms ease;
   transform: ${({ $collapse }) =>
-    $collapse ? "rotate(-90deg)" : "rotate(90deg)"};
+    $collapse ? "rotate(90deg)" : "rotate(0deg)"};
 `;
 
 export { StyledBoardSection, StyledCollapseIcon };

--- a/src/components/layout/BoardSection/types.ts
+++ b/src/components/layout/BoardSection/types.ts
@@ -1,3 +1,5 @@
 type SectionBackground = "gray" | "light";
 
-export type { SectionBackground };
+type SectionOrientation = "horizontal" | "vertical";
+
+export type { SectionBackground, SectionOrientation };


### PR DESCRIPTION
This task does not include functionality except the scalable option.

Changed the border of the SummaryCard component to be closer to what is in the designs.

The task "Import the accordion component" was removed from the board because it was not necessary and it was not the appropriate component for this development.

![image](https://github.com/selsa-inube/crediboard/assets/87447257/0c1b9e16-da5b-4689-85ec-1ee249517106)
