### PR TITLE
Create a DB mock for requests

### DIFF
--- a/src/mocks/design/themes/index.ts
+++ b/src/mocks/design/themes/index.ts
@@ -3,6 +3,11 @@ import { fondecom } from "@mocks/design/themes/fondecom";
 import { presente } from "@mocks/design/themes/presente";
 import { corbanca } from "@mocks/design/themes/corbanca";
 
-const themes = [fondecom, presente, cooservunal, corbanca];
+const themes = [
+  { bussinessUnit: "fondecom", tokens: fondecom },
+  { bussinessUnit: "presente", tokens: presente },
+  { bussinessUnit: "cooservunal", tokens: cooservunal },
+  { bussinessUnit: "corbanca", tokens: corbanca },
+];
 
 export { themes };

--- a/src/mocks/requests/requests.mock.ts
+++ b/src/mocks/requests/requests.mock.ts
@@ -1,0 +1,32 @@
+import { Requests } from "@services/types";
+
+export const mockRequests: Requests[] = [
+  {
+    k_Prospe: 999998,
+    n_Prospe: "TEST PROSPECT GNR ONE PRODUCT",
+    f_Prospe: "2022-03-18T00:00:00-05:00",
+    v_Monto: 30000000,
+    k_Idterc: 212758,
+    k_Desdin: "LIBRE",
+    i_Estprs: "TRAMITE_DESEMBOLSO",
+    n_Desdin: "LIBRE GNR TEST",
+    aanumnit: "1000970878",
+    nnasocia: "RAMOS CONTRERAS MYKE ANDRES",
+    n_Descr_Etapa: "Tramite de Desembolso",
+    n_Descr_Tarea: "Confirmar que el tramite de Desembolso se ha efectuado",
+  },
+  {
+    k_Prospe: 999999,
+    n_Prospe: "TEST PROSPECT GNR TWO PRODUCTS",
+    f_Prospe: "2022-03-18T00:00:00-05:00",
+    v_Monto: 30000000,
+    k_Idterc: 212758,
+    k_Desdin: "LIBRE",
+    i_Estprs: "TRAMITE_DESEMBOLSO",
+    n_Desdin: "LIBRE GNR TEST",
+    aanumnit: "1000970878",
+    nnasocia: "RAMOS CONTRERAS MYKE ANDRES",
+    n_Descr_Etapa: "Tramite de Desembolso",
+    n_Descr_Tarea: "Confirmar que el tramite de Desembolso se ha efectuado",
+  },
+];

--- a/src/mocks/utils/initializeDataDB.ts
+++ b/src/mocks/utils/initializeDataDB.ts
@@ -2,9 +2,11 @@ import localforage from "localforage";
 
 import { intializedData } from "@src/mocks/utils/dataMock.service";
 import { themes } from "@mocks/design/themes";
+import { mockRequests } from "@mocks/requests/requests.mock";
 
 export function initializeDataDB() {
   localforage.clear();
 
   intializedData<(typeof themes)[number]>("themes", themes);
+  intializedData<(typeof mockRequests)[number]>("requests", mockRequests);
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,16 @@
+interface Requests {
+  k_Prospe: number;
+  n_Prospe: string;
+  f_Prospe: string;
+  v_Monto: number;
+  k_Idterc: number;
+  k_Desdin: string;
+  i_Estprs: string;
+  n_Desdin: string;
+  aanumnit: string;
+  nnasocia: string;
+  n_Descr_Etapa: string;
+  n_Descr_Tarea: string;
+}
+
+export type { Requests };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "@mocks/*": ["src/mocks/*"],
       "@context/*": ["src/context/*"],
       "@pages/*": ["src/pages/*"],
-      "@assets/*": ["src/assets/*"]
+      "@assets/*": ["src/assets/*"],
+      "@services/*": ["src/services/*"]
     },
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "@ptypes": path.resolve(__dirname, "./src/types"),
       "@forms": path.resolve(__dirname, "./src/forms"),
       "@assets": path.resolve(__dirname, "./src/assets"),
+      "@services": path.resolve(__dirname, "./src/services"),
     },
   },
 });


### PR DESCRIPTION
The requests service mock is created from the existent data created in Oracle DB.
For the appropriate management of this data structure, a new interface is created in the folder "services". It is important to notice that the mock folder will be deleted, however, the Requests Interface will be used for the real service, therefore, those elements must be isolated.

This merge also solves the issue related in the cb26, including a new key "bussinessUnit" into the themes mock.

![image](https://github.com/selsa-inube/crediboard/assets/123512032/8cf27e11-51cb-4a7a-8966-d456559d41ab)
