### PR TITLE
Ab/cb30/create layout l008 requirements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,15 @@ import { useAuth } from "@inube/auth";
 
 import { Login } from "@pages/login";
 import { initializeDataDB } from "@mocks/utils/initializeDataDB";
+import { ErrorPage } from "@components/layout/ErrorPage";
+import { FinancialReporting } from "@pages/board/outlets/financialReporting";
+import { Requirements } from "@pages/board/outlets/boardlayout/Requirements";
+import { dataRequirements } from "@pages/board/outlets/boardlayout/Requirements/config";
 
 import { GlobalStyles } from "./styles/global";
 import { LoginRoutes } from "./routes/login";
 import { BoardRoutes } from "./routes/board";
 import AppContextProvider, { AppContext } from "./context/AppContext";
-import { ErrorPage } from "./components/layout/ErrorPage";
-import { FinancialReporting } from "./pages/board/outlets/financialReporting";
-import { Requirements } from "./pages/board/outlets/boardlayout/Requirements";
-import { dataRequirements } from "./pages/board/outlets/boardlayout/Requirements/config";
 
 function LogOut() {
   localStorage.clear();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter(
       <Route path="/*" element={<BoardRoutes />} />
       <Route path="logout" element={<LogOut />} />
       <Route
-        path="financial-reporting"
+        path="solicitud/:id"
         element={
           <FinancialReporting
             requirements={<Requirements data={dataRequirements} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,6 @@ import { useAuth } from "@inube/auth";
 import { Login } from "@pages/login";
 import { initializeDataDB } from "@mocks/utils/initializeDataDB";
 import { ErrorPage } from "@components/layout/ErrorPage";
-import { FinancialReporting } from "@pages/board/outlets/financialReporting";
-import { Requirements } from "@pages/board/outlets/boardlayout/Requirements";
-import { dataRequirements } from "@pages/board/outlets/boardlayout/Requirements/config";
 
 import { GlobalStyles } from "./styles/global";
 import { LoginRoutes } from "./routes/login";
@@ -38,14 +35,6 @@ const router = createBrowserRouter(
       <Route path="login/*" element={<LoginRoutes />} />
       <Route path="/*" element={<BoardRoutes />} />
       <Route path="logout" element={<LogOut />} />
-      <Route
-        path="solicitud/:id"
-        element={
-          <FinancialReporting
-            requirements={<Requirements data={dataRequirements} />}
-          />
-        }
-      />
     </>
   )
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import { BoardRoutes } from "./routes/board";
 import AppContextProvider, { AppContext } from "./context/AppContext";
 import { ErrorPage } from "./components/layout/ErrorPage";
 import { FinancialReporting } from "./pages/board/outlets/financialReporting";
+import { Requirements } from "./pages/board/outlets/boardlayout/Requirements";
+import { dataRequirements } from "./pages/board/outlets/boardlayout/Requirements/config";
 
 function LogOut() {
   localStorage.clear();
@@ -36,7 +38,14 @@ const router = createBrowserRouter(
       <Route path="login/*" element={<LoginRoutes />} />
       <Route path="/*" element={<BoardRoutes />} />
       <Route path="logout" element={<LogOut />} />
-      <Route path="financial-reporting" element={<FinancialReporting />} />
+      <Route
+        path="financial-reporting"
+        element={
+          <FinancialReporting
+            requirements={<Requirements data={dataRequirements} />}
+          />
+        }
+      />
     </>
   )
 );

--- a/src/components/data/Fieldset/index.tsx
+++ b/src/components/data/Fieldset/index.tsx
@@ -1,25 +1,50 @@
-import { Stack, Text } from "@inube/design-system";
+import { MdAdd } from "react-icons/md";
+
+import { Button, Stack, Text, inube } from "@inube/design-system";
 
 import { StyledContainerFieldset } from "./styles";
+
+interface IPtionsButton {
+  title: string;
+  onClick?: () => void;
+}
 
 interface IFieldsetProps {
   title: string;
   descriptionTitle?: string;
   children: JSX.Element | JSX.Element[];
+  activeButton?: IPtionsButton;
 }
 
 export const Fieldset = (props: IFieldsetProps) => {
-  const { children, title, descriptionTitle } = props;
+  const { children, title, descriptionTitle, activeButton } = props;
 
   return (
-    <Stack direction="column" gap="8px">
-      <Stack padding="s0 s200" gap="4px 8px">
-        <Text type="title" appearance="gray">
-          {`${title} `}
-        </Text>
-        <Text type="title" ellipsis>
-          {descriptionTitle}
-        </Text>
+    <Stack
+      direction="column"
+      gap={inube.spacing.s100}
+      width="-webkit-fill-available"
+    >
+      <Stack justifyContent={activeButton && "space-between"}>
+        <Stack gap={inube.spacing.s100}>
+          <Text type="title" appearance="gray">
+            {`${title} `}
+          </Text>
+          <Text type="title" ellipsis>
+            {descriptionTitle}
+          </Text>
+        </Stack>
+        {activeButton && (
+          <Stack>
+            <Button
+              iconBefore={<MdAdd />}
+              spacing="compact"
+              onClick={activeButton.onClick}
+            >
+              {activeButton.title}
+            </Button>
+          </Stack>
+        )}
       </Stack>
       <StyledContainerFieldset>{children}</StyledContainerFieldset>
     </Stack>

--- a/src/components/data/Fieldset/styles.ts
+++ b/src/components/data/Fieldset/styles.ts
@@ -13,4 +13,14 @@ export const StyledContainerFieldset = styled.div`
       theme?.color?.stroke?.divider?.regular ||
       inube.color.stroke.divider.regular};
   padding: ${({ theme }) => theme?.spacing?.s200 || inube.spacing.s200};
+
+  &::-webkit-scrollbar {
+    border-radius: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) =>
+      theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular};
+    border-radius: 8px;
+  }
 `;

--- a/src/components/data/Fieldset/styles.ts
+++ b/src/components/data/Fieldset/styles.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { inube } from "@inube/design-system";
 
 export const StyledContainerFieldset = styled.div`
+  overflow-y: auto;
   border-radius: 8px;
   border-width: 2px;
   border-style: solid;

--- a/src/components/data/TableBoard/interface.tsx
+++ b/src/components/data/TableBoard/interface.tsx
@@ -7,6 +7,7 @@ import {
   StyledThead,
   StyledTr,
   StyledTh,
+  StyledTd,
 } from "./styles";
 
 import { ITableBoardProps } from ".";
@@ -43,7 +44,7 @@ export const TableBoardUI = (props: ITableBoardUIProps) => {
               $zebraEffect={index % 2 === 0}
             >
               {titlesList.map((title) => (
-                <td key={title}>
+                <StyledTd key={title}>
                   {typeof entry[title] !== "string" ? (
                     entry[title]
                   ) : (
@@ -51,7 +52,7 @@ export const TableBoardUI = (props: ITableBoardUIProps) => {
                       {entry[title]}
                     </Text>
                   )}
-                </td>
+                </StyledTd>
               ))}
               {actions?.map((action) => (
                 <td key={action.id}>{action.content(entry)}</td>

--- a/src/components/data/TableBoard/stories/mockStories.tsx
+++ b/src/components/data/TableBoard/stories/mockStories.tsx
@@ -58,7 +58,7 @@ export const actionsMock: IAction[] = [
         icon={<MdOutlineCheckCircle />}
         appearance="primary"
         spacing="compact"
-        cursorHoverh
+        cursorHover
         size="18px"
         onClick={() => resiveData(data)}
       />

--- a/src/components/data/TableBoard/styles.ts
+++ b/src/components/data/TableBoard/styles.ts
@@ -50,3 +50,8 @@ export const StyledTr = styled.tr<IStyledTdbodyContainer>`
       ? theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular
       : theme?.color?.surface?.gray?.clear || inube.color.surface.gray.clear};
 `;
+
+export const StyledTd = styled.td`
+  min-width: 218px;
+  max-width: 310px;
+`;

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -129,16 +129,19 @@ export const actionsRequirements = [
 
 export const dataRequirements = [
   {
+    id: "tabla1",
     titlesRequirements: titlesRequirements[0],
     entriesRequirements: entriesRequirements[0],
     actionsRequirements: actionsRequirements[0],
   },
   {
+    id: "tabla2",
     titlesRequirements: titlesRequirements[1],
     entriesRequirements: entriesRequirements[1],
     actionsRequirements: actionsRequirements[0],
   },
   {
+    id: "tabla3",
     titlesRequirements: titlesRequirements[2],
     entriesRequirements: entriesRequirements[2],
     actionsRequirements: actionsRequirements[0],

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -64,12 +64,12 @@ export const entriesRequirements: IEntries[][] = [
     {
       id: "seis",
       "Requisitos documentales": "Desprendible de pago",
-      tag: <Tag label="Cumple" appearance="success" />,
+      tag: <Tag label="Sin Evaluar" appearance="warning" />,
     },
     {
       id: "siete",
       "Requisitos documentales": "Declaración de renta",
-      tag: <Tag label="Cumple" appearance="success" />,
+      tag: <Tag label="Sin Evaluar" appearance="warning" />,
     },
   ],
   [
@@ -113,7 +113,7 @@ export const actionsRequirements = [
             icon={<MdOutlineCheckCircle />}
             appearance="primary"
             spacing="compact"
-            cursorHoverh
+            cursorHover
             size="18px"
             onClick={() => resiveData(data)}
             disabled={

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -1,0 +1,138 @@
+import { Icon, Tag } from "@inube/design-system";
+import { IEntries } from "@src/components/data/TableBoard/types";
+import { MdAddCircleOutline, MdOutlineCheckCircle } from "react-icons/md";
+
+const resiveData = (data: IEntries) => {
+  console.log(data, "function que recibe data");
+};
+
+export const titlesRequirements = [
+  [
+    {
+      id: "uno",
+      titleName: "Validaciones del sistema",
+      priority: 1,
+    },
+  ],
+  [
+    {
+      id: "dos",
+      titleName: "Requisitos documentales",
+      priority: 1,
+    },
+  ],
+  [
+    {
+      id: "tres",
+      titleName: "Validaciones humanas",
+      priority: 1,
+    },
+  ],
+];
+
+export const entriesRequirements: IEntries[][] = [
+  [
+    {
+      id: "uno",
+      "Validaciones del sistema": "Que el asociado sea activo",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "dos",
+      "Validaciones del sistema": "Que este al días con las obligaciones",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "tres",
+      "Validaciones del sistema": "Que este al días con las obligaciones",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "cuatro",
+      "Validaciones del sistema": "Que tenga más de 30 años",
+      tag: <Tag label="No Cumple" appearance="error" />,
+    },
+  ],
+  [
+    {
+      id: "cinco",
+      "Requisitos documentales": "Imagenes de la Cédula de ciudadanía",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "seis",
+      "Requisitos documentales": "Desprendible de pago",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "siete",
+      "Requisitos documentales": "Declaración de renta",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+  ],
+  [
+    {
+      id: "ocho",
+      "Validaciones humanas": "Referencias laborales",
+      tag: <Tag label="Cumple" appearance="success" />,
+    },
+    {
+      id: "nueve",
+      "Validaciones humanas": "Proponer un codeudor",
+      tag: <Tag label="No Cumple" appearance="error" />,
+    },
+  ],
+];
+
+export const actionsRequirements = [
+  [
+    {
+      id: "agregar",
+      actionName: "Agregar",
+      content: (data: IEntries) => (
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <Icon
+            icon={<MdAddCircleOutline />}
+            appearance="primary"
+            onClick={() => resiveData(data)}
+            spacing="compact"
+            size="18px"
+            cursorHover
+          />
+        </div>
+      ),
+    },
+    {
+      id: "aprobar",
+      actionName: "Aprobar",
+      content: (data: IEntries) => (
+        <Icon
+          icon={<MdOutlineCheckCircle />}
+          appearance="primary"
+          spacing="compact"
+          cursorHoverh
+          size="18px"
+          onClick={() => resiveData(data)}
+        />
+      ),
+    },
+  ],
+];
+
+export const dataRequirements = [
+  {
+    titlesRequirements: titlesRequirements[0],
+    entriesRequirements: entriesRequirements[0],
+    actionsRequirements: actionsRequirements[0],
+  },
+  {
+    titlesRequirements: titlesRequirements[1],
+    entriesRequirements: entriesRequirements[1],
+    actionsRequirements: actionsRequirements[0],
+  },
+  {
+    titlesRequirements: titlesRequirements[2],
+    entriesRequirements: entriesRequirements[2],
+    actionsRequirements: actionsRequirements[0],
+  },
+];

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -1,10 +1,10 @@
 import { isValidElement } from "react";
 import { MdAddCircleOutline, MdOutlineCheckCircle } from "react-icons/md";
-import { Icon, Tag } from "@inube/design-system";
+import { Icon, Stack, Tag } from "@inube/design-system";
 
 import { IEntries } from "@components/data/TableBoard/types";
 
-const resiveData = (data: IEntries) => {
+const receiveData = (data: IEntries) => {
   console.log(data, "function que recibe data");
 };
 
@@ -92,36 +92,36 @@ export const actionsRequirements = [
       id: "agregar",
       actionName: "Agregar",
       content: (data: IEntries) => (
-        <div style={{ display: "flex", justifyContent: "center" }}>
+        <Stack justifyContent="center">
           <Icon
             icon={<MdAddCircleOutline />}
             appearance="primary"
-            onClick={() => resiveData(data)}
+            onClick={() => receiveData(data)}
             spacing="compact"
             size="18px"
             cursorHover
           />
-        </div>
+        </Stack>
       ),
     },
     {
       id: "aprobar",
       actionName: "Aprobar",
       content: (data: IEntries) => (
-        <div style={{ display: "flex", justifyContent: "center" }}>
+        <Stack justifyContent="center">
           <Icon
             icon={<MdOutlineCheckCircle />}
             appearance="primary"
             spacing="compact"
             cursorHover
             size="18px"
-            onClick={() => resiveData(data)}
+            onClick={() => receiveData(data)}
             disabled={
               isValidElement(data?.tag) &&
               data?.tag?.props?.label === "No Cumple"
             }
           />
-        </div>
+        </Stack>
       ),
     },
   ],

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -1,4 +1,6 @@
+import { isValidElement } from "react";
 import { Icon, Tag } from "@inube/design-system";
+
 import { IEntries } from "@src/components/data/TableBoard/types";
 import { MdAddCircleOutline, MdOutlineCheckCircle } from "react-icons/md";
 
@@ -106,14 +108,20 @@ export const actionsRequirements = [
       id: "aprobar",
       actionName: "Aprobar",
       content: (data: IEntries) => (
-        <Icon
-          icon={<MdOutlineCheckCircle />}
-          appearance="primary"
-          spacing="compact"
-          cursorHoverh
-          size="18px"
-          onClick={() => resiveData(data)}
-        />
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <Icon
+            icon={<MdOutlineCheckCircle />}
+            appearance="primary"
+            spacing="compact"
+            cursorHoverh
+            size="18px"
+            onClick={() => resiveData(data)}
+            disabled={
+              isValidElement(data?.tag) &&
+              data?.tag?.props?.label === "No Cumple"
+            }
+          />
+        </div>
       ),
     },
   ],

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -4,6 +4,11 @@ import { Icon, Stack, Tag } from "@inube/design-system";
 
 import { IEntries } from "@components/data/TableBoard/types";
 
+export const dataButton = {
+  title: "Agregar Requesito",
+  onClick: () => console.log("Agregar"),
+};
+
 const receiveData = (data: IEntries) => {
   console.log(data, "function que recibe data");
 };

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -103,7 +103,7 @@ export const actionsRequirements = [
             appearance="primary"
             onClick={() => receiveData(data)}
             spacing="compact"
-            size="18px"
+            size="24px"
             cursorHover
           />
         </Stack>
@@ -119,7 +119,7 @@ export const actionsRequirements = [
             appearance="primary"
             spacing="compact"
             cursorHover
-            size="18px"
+            size="24px"
             onClick={() => receiveData(data)}
             disabled={
               isValidElement(data?.tag) &&

--- a/src/pages/board/outlets/boardlayout/Requirements/config.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/config.tsx
@@ -1,8 +1,8 @@
 import { isValidElement } from "react";
+import { MdAddCircleOutline, MdOutlineCheckCircle } from "react-icons/md";
 import { Icon, Tag } from "@inube/design-system";
 
-import { IEntries } from "@src/components/data/TableBoard/types";
-import { MdAddCircleOutline, MdOutlineCheckCircle } from "react-icons/md";
+import { IEntries } from "@components/data/TableBoard/types";
 
 const resiveData = (data: IEntries) => {
   console.log(data, "function que recibe data");

--- a/src/pages/board/outlets/boardlayout/Requirements/index.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/index.tsx
@@ -19,7 +19,7 @@ export const Requirements = (props: IRequirementsProps) => {
 
   return (
     <Stack>
-      <Fieldset title="Requerimientos">
+      <Fieldset title="Requisitos">
         {data.map((item) => (
           <TableBoard
             key={item.id}

--- a/src/pages/board/outlets/boardlayout/Requirements/index.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/index.tsx
@@ -5,6 +5,7 @@ import { TableBoard } from "@components/data/TableBoard";
 import { IAction, IEntries, ITitle } from "@components/data/TableBoard/types";
 
 interface IData {
+  id: string;
   titlesRequirements: ITitle[];
   entriesRequirements: IEntries[];
   actionsRequirements: IAction[];
@@ -19,10 +20,10 @@ export const Requirements = (props: IRequirementsProps) => {
   return (
     <Stack>
       <Fieldset title="Requerimientos">
-        {data.map((item, index) => (
+        {data.map((item) => (
           <TableBoard
-            key={index}
-            id={index.toString()}
+            key={item.id}
+            id={item.id}
             titles={item.titlesRequirements}
             entries={item.entriesRequirements}
             actions={item.actionsRequirements}

--- a/src/pages/board/outlets/boardlayout/Requirements/index.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/index.tsx
@@ -3,6 +3,7 @@ import { Stack } from "@inube/design-system";
 import { Fieldset } from "@components/data/Fieldset";
 import { TableBoard } from "@components/data/TableBoard";
 import { IAction, IEntries, ITitle } from "@components/data/TableBoard/types";
+import { dataButton } from "./config";
 
 interface IData {
   id: string;
@@ -19,16 +20,18 @@ export const Requirements = (props: IRequirementsProps) => {
 
   return (
     <Stack>
-      <Fieldset title="Requisitos">
-        {data.map((item) => (
-          <TableBoard
-            key={item.id}
-            id={item.id}
-            titles={item.titlesRequirements}
-            entries={item.entriesRequirements}
-            actions={item.actionsRequirements}
-          />
-        ))}
+      <Fieldset title="Requisitos" activeButton={dataButton}>
+        <div style={{ height: "340px" }}>
+          {data.map((item) => (
+            <TableBoard
+              key={item.id}
+              id={item.id}
+              titles={item.titlesRequirements}
+              entries={item.entriesRequirements}
+              actions={item.actionsRequirements}
+            />
+          ))}
+        </div>
       </Fieldset>
     </Stack>
   );

--- a/src/pages/board/outlets/boardlayout/Requirements/index.tsx
+++ b/src/pages/board/outlets/boardlayout/Requirements/index.tsx
@@ -1,0 +1,34 @@
+import { Stack } from "@inube/design-system";
+
+import { Fieldset } from "@components/data/Fieldset";
+import { TableBoard } from "@components/data/TableBoard";
+import { IAction, IEntries, ITitle } from "@components/data/TableBoard/types";
+
+interface IData {
+  titlesRequirements: ITitle[];
+  entriesRequirements: IEntries[];
+  actionsRequirements: IAction[];
+}
+
+export interface IRequirementsProps {
+  data: IData[];
+}
+export const Requirements = (props: IRequirementsProps) => {
+  const { data } = props;
+
+  return (
+    <Stack>
+      <Fieldset title="Requerimientos">
+        {data.map((item, index) => (
+          <TableBoard
+            key={index}
+            id={index.toString()}
+            titles={item.titlesRequirements}
+            entries={item.entriesRequirements}
+            actions={item.actionsRequirements}
+          />
+        ))}
+      </Fieldset>
+    </Stack>
+  );
+};

--- a/src/routes/board.tsx
+++ b/src/routes/board.tsx
@@ -1,9 +1,11 @@
 import { Route, Routes } from "react-router-dom";
 
-import { ErrorPage } from "@src/components/layout/ErrorPage";
-import { ContainerSections } from "@src/components/layout/ContainerSections";
-import { Board } from "@src/pages/board";
+import { ErrorPage } from "@components/layout/ErrorPage";
+import { Board } from "@pages/board";
 import { BoardLayout } from "@pages/board/outlets/boardlayout";
+import { FinancialReporting } from "@pages/board/outlets/financialReporting";
+import { Requirements } from "@pages/board/outlets/boardlayout/Requirements";
+import { dataRequirements } from "@pages/board/outlets/boardlayout/Requirements/config";
 
 function BoardRoutes() {
   return (
@@ -11,8 +13,12 @@ function BoardRoutes() {
       <Route path="/" element={<Board />}>
         <Route path="/" element={<BoardLayout />} />
         <Route
-          path="/solicitud/:solicitud_id"
-          element={<ContainerSections />}
+          path="solicitud/:id"
+          element={
+            <FinancialReporting
+              requirements={<Requirements data={dataRequirements} />}
+            />
+          }
         />
       </Route>
       <Route path="/*" element={<ErrorPage />} />


### PR DESCRIPTION
Implement the `Requirements` component to improve the way requirements are visualised. Key changes include:

this section will show the requirements mock to implement the layout, which will be implemented. 

Updated the `Fieldset` component to include a ‘Requirements’ heading.

Mapped through the data passed to `Requirements` to generate multiple `TableBoard` components. Each `TableBoard` receives a unique set of `titles`, `entries` and `actions`.

![image](https://github.com/selsa-inube/crediboard/assets/74839801/00274ad3-9569-48a8-827d-63d931889e89)
![image](https://github.com/selsa-inube/crediboard/assets/74839801/adb97200-2533-4d58-ba43-2d9ba72b54f3)

