### PR TITLE
Include the requests states in the board page

### DIFF
--- a/src/components/cards/SummaryCard/index.tsx
+++ b/src/components/cards/SummaryCard/index.tsx
@@ -1,16 +1,14 @@
-import { Stack, Text, Icon, inube } from "@inube/design-system";
-import { MdOutlineMessage, MdOutlinePushPin } from "react-icons/md";
+import { useState } from "react";
 
-import { currencyFormat } from "@utils/formatData/currency";
 import {
   truncateTextToMaxLength,
   capitalizeFirstLetter,
   capitalizeFirstLetterEachWord,
 } from "@utils/formatData/text";
 
-import { StyledSummaryCard, StyledDivider } from "./styles";
+import { SummaryCardUI } from "./interface";
 
-interface ISummaryCardProps {
+interface SummaryCardProps {
   rad: number;
   date: string;
   name: string;
@@ -19,9 +17,10 @@ interface ISummaryCardProps {
   toDo: string;
   isPinned?: boolean;
   hasMessage?: boolean;
+  onPinChange?: (isPinned: boolean) => void;
 }
 
-function SummaryCard(props: ISummaryCardProps) {
+function SummaryCard(props: SummaryCardProps) {
   const {
     rad,
     date,
@@ -31,69 +30,32 @@ function SummaryCard(props: ISummaryCardProps) {
     toDo,
     isPinned = false,
     hasMessage = false,
+    onPinChange,
   } = props;
+
+  const [pinned, setPinned] = useState(isPinned);
+
+  const handlePinClick = () => {
+    setPinned(!pinned);
+    onPinChange && onPinChange(!pinned);
+  };
+
   return (
-    <StyledSummaryCard>
-      <Stack
-        direction="column"
-        padding="s100"
-        justifyContent="space-between"
-        height="100%"
-      >
-        <Stack justifyContent="space-between">
-          <Text size="small" appearance="gray">
-            No. Rad.:{rad}
-          </Text>
-          <Text size="small" appearance="gray">
-            {date}
-          </Text>
-        </Stack>
-        <Text type="label">{capitalizeFirstLetterEachWord(name)}</Text>
-        <Text size="medium" appearance="gray">
-          Destino:
-        </Text>
-        <Text type="label">
-          {capitalizeFirstLetter(truncateTextToMaxLength(destination, 60))}
-        </Text>
-        <Stack gap={inube.spacing.s100}>
-          <Text size="medium" appearance="gray">
-            Valor:
-          </Text>
-          <Text type="label">
-            {value === 0 ? "$ 0" : currencyFormat(value)}
-          </Text>
-        </Stack>
-        <Text size="medium" appearance="gray">
-          Actividad en ejecución:
-        </Text>
-        <Text type="label">
-          {capitalizeFirstLetter(truncateTextToMaxLength(toDo, 60))}
-        </Text>
-        <Stack direction="column" gap={inube.spacing.s075}>
-          <StyledDivider />
-          <Stack gap={inube.spacing.s100} justifyContent="flex-end">
-            {hasMessage && (
-              <Icon
-                icon={<MdOutlineMessage />}
-                appearance="dark"
-                size="20px"
-                cursorHover
-              />
-            )}
-            {isPinned && (
-              <Icon
-                icon={<MdOutlinePushPin />}
-                appearance="dark"
-                size="20px"
-                cursorHover
-              />
-            )}
-          </Stack>
-        </Stack>
-      </Stack>
-    </StyledSummaryCard>
+    <SummaryCardUI
+      rad={rad}
+      date={date}
+      name={truncateTextToMaxLength(capitalizeFirstLetterEachWord(name))}
+      destination={capitalizeFirstLetter(
+        truncateTextToMaxLength(destination, 60)
+      )}
+      value={value}
+      toDo={capitalizeFirstLetter(truncateTextToMaxLength(toDo, 60))}
+      isPinned={pinned}
+      hasMessage={hasMessage}
+      onPinChange={handlePinClick}
+    />
   );
 }
 
 export { SummaryCard };
-export type { ISummaryCardProps };
+export type { SummaryCardProps };

--- a/src/components/cards/SummaryCard/interface.tsx
+++ b/src/components/cards/SummaryCard/interface.tsx
@@ -1,0 +1,80 @@
+import { Stack, Text, Icon, inube } from "@inube/design-system";
+import { MdOutlineMessage, MdOutlinePushPin, MdPushPin } from "react-icons/md";
+
+import { currencyFormat } from "@utils/formatData/currency";
+
+import { StyledSummaryCard, StyledDivider } from "./styles";
+import { SummaryCardProps } from ".";
+
+function SummaryCardUI(props: SummaryCardProps) {
+  const {
+    rad,
+    date,
+    name,
+    destination,
+    value,
+    toDo,
+    isPinned = false,
+    hasMessage = false,
+    onPinChange,
+  } = props;
+
+  return (
+    <StyledSummaryCard>
+      <Stack
+        direction="column"
+        padding="s100"
+        justifyContent="space-between"
+        height="100%"
+      >
+        <Stack justifyContent="space-between">
+          <Text size="small" appearance="gray">
+            No. Rad.:{rad}
+          </Text>
+          <Text size="small" appearance="gray">
+            {date}
+          </Text>
+        </Stack>
+        <Text type="label">{name}</Text>
+        <Text size="medium" appearance="gray">
+          Destino:
+        </Text>
+        <Text type="label">{destination}</Text>
+        <Stack gap={inube.spacing.s100}>
+          <Text size="medium" appearance="gray">
+            Valor:
+          </Text>
+          <Text type="label">
+            {value === 0 ? "$ 0" : currencyFormat(value)}
+          </Text>
+        </Stack>
+        <Text size="medium" appearance="gray">
+          Actividad en ejecución:
+        </Text>
+        <Text type="label">{toDo}</Text>
+        <Stack direction="column" gap={inube.spacing.s075}>
+          <StyledDivider />
+          <Stack gap={inube.spacing.s100} justifyContent="flex-end">
+            {hasMessage && (
+              <Icon
+                icon={<MdOutlineMessage />}
+                appearance="dark"
+                size="20px"
+                cursorHover
+              />
+            )}
+            <Icon
+              icon={isPinned ? <MdPushPin /> : <MdOutlinePushPin />}
+              appearance={isPinned ? "dark" : "gray"}
+              size="20px"
+              cursorHover
+              onClick={onPinChange}
+            />
+          </Stack>
+        </Stack>
+      </Stack>
+    </StyledSummaryCard>
+  );
+}
+
+export { SummaryCardUI };

--- a/src/components/cards/SummaryCard/stories/SummaryCard.stories.tsx
+++ b/src/components/cards/SummaryCard/stories/SummaryCard.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryFn, Meta } from "@storybook/react";
 
-import { SummaryCard, ISummaryCardProps } from "..";
+import { SummaryCard, SummaryCardProps } from "..";
 
 import { props } from "./props";
 
@@ -10,7 +10,7 @@ const story: Meta<typeof SummaryCard> = {
   title: "components/cards/SummaryCard",
 };
 
-export const Default: StoryFn<ISummaryCardProps> = (args) => (
+export const Default: StoryFn<SummaryCardProps> = (args) => (
   <SummaryCard {...args} />
 );
 

--- a/src/components/layout/BoardSection/index.tsx
+++ b/src/components/layout/BoardSection/index.tsx
@@ -1,14 +1,9 @@
 import { useState } from "react";
-import { Stack, Text, Icon, useMediaQuery, inube } from "@inube/design-system";
-import { MdOutlineChevronRight } from "react-icons/md";
 
-import { SummaryCard } from "@components/cards/SummaryCard";
 import { Requests } from "@services/types";
-import { formatISODatetoCustomFormat } from "@utils/formatData/date";
-import { capitalizeFirstLetter } from "@utils/formatData/text";
 
-import { StyledBoardSection, StyledCollapseIcon } from "./styles";
 import { SectionBackground, SectionOrientation } from "./types";
+import { BoardSectionUI } from "./interface";
 
 interface BoardSectionProps {
   id: string;
@@ -16,6 +11,7 @@ interface BoardSectionProps {
   sectionBackground: SectionBackground;
   orientation: SectionOrientation;
   sectionInformation: Requests[];
+  showPinnedOnly: boolean;
 }
 
 function BoardSection(props: BoardSectionProps) {
@@ -25,97 +21,37 @@ function BoardSection(props: BoardSectionProps) {
     sectionBackground = "light",
     orientation = "vertical",
     sectionInformation,
+    showPinnedOnly,
   } = props;
 
-  const filteredRequests = sectionInformation.filter(
-    (request) => request.i_Estprs === id
-  );
-
-  const disabledCollapse = filteredRequests.length === 0;
-
-  const smallScreen = useMediaQuery("(max-width: 595px)");
+  const filteredRequests = showPinnedOnly
+    ? sectionInformation.filter(
+        (request) => request.i_Estprs === id && request.isPinned
+      )
+    : sectionInformation.filter((request) => request.i_Estprs === id);
 
   const [collapse, setCollapse] = useState(false);
 
   const handleCollapse = () => {
-    if (!disabledCollapse) {
+    if (filteredRequests.length !== 0) {
       setCollapse(!collapse);
     }
   };
+
+  const handlePinChange = (request: Requests, isPinned: boolean) => {
+    request.isPinned = isPinned;
+  };
+
   return (
-    <StyledBoardSection
-      $sectionBackground={sectionBackground}
-      $orientation={orientation}
-    >
-      <Stack
-        justifyContent={
-          orientation === "vertical" ? "space-between" : "flex-start"
-        }
-        alignItems="end"
-        gap={inube.spacing.s300}
-      >
-        <Stack
-          alignItems="end"
-          gap={inube.spacing.s100}
-          width={orientation === "vertical" ? "180px" : "auto"}
-          height={orientation === "vertical" ? "56px" : "auto"}
-        >
-          {orientation !== "vertical" && (
-            <StyledCollapseIcon
-              $collapse={collapse}
-              $disabledCollapse={disabledCollapse}
-              onClick={handleCollapse}
-            >
-              <Icon
-                icon={<MdOutlineChevronRight />}
-                disabled={disabledCollapse}
-                appearance="dark"
-                size="26px"
-                cursorHover
-              />
-            </StyledCollapseIcon>
-          )}
-          <Text
-            type={
-              orientation === "vertical" || smallScreen ? "title" : "headline"
-            }
-            size={
-              orientation === "vertical" || smallScreen ? "large" : "medium"
-            }
-          >
-            {sectionTitle}
-          </Text>
-        </Stack>
-        <Text type="title" size="medium">
-          {filteredRequests.length}
-        </Text>
-      </Stack>
-      {(collapse || orientation === "vertical") && (
-        <Stack
-          wrap="wrap"
-          alignItems="center"
-          direction={orientation === "vertical" ? "column" : "row"}
-          justifyContent={smallScreen ? "center" : "flex-start"}
-          gap={inube.spacing.s250}
-        >
-          {filteredRequests.map((request, index) => (
-            <SummaryCard
-              key={index}
-              rad={request.k_Prospe}
-              date={capitalizeFirstLetter(
-                formatISODatetoCustomFormat(request.f_Prospe)
-              )}
-              name={request.nnasocia}
-              destination={request.k_Desdin}
-              value={request.v_Monto}
-              toDo={request.n_Descr_Tarea}
-              isPinned={true}
-              hasMessage={true}
-            />
-          ))}
-        </Stack>
-      )}
-    </StyledBoardSection>
+    <BoardSectionUI
+      sectionTitle={sectionTitle}
+      sectionBackground={sectionBackground}
+      orientation={orientation}
+      filteredRequests={filteredRequests}
+      collapse={collapse}
+      handleCollapse={handleCollapse}
+      handlePinChange={handlePinChange}
+    />
   );
 }
 

--- a/src/components/layout/BoardSection/interface.tsx
+++ b/src/components/layout/BoardSection/interface.tsx
@@ -1,0 +1,113 @@
+import { Stack, Text, Icon, useMediaQuery, inube } from "@inube/design-system";
+import { MdOutlineChevronRight } from "react-icons/md";
+
+import { formatISODatetoCustomFormat } from "@utils/formatData/date";
+import { capitalizeFirstLetter } from "@utils/formatData/text";
+import { SummaryCard } from "@components/cards/SummaryCard";
+import { Requests } from "@services/types";
+
+import { SectionBackground, SectionOrientation } from "./types";
+import { StyledBoardSection, StyledCollapseIcon } from "./styles";
+
+interface BoardSectionUIProps {
+  sectionTitle: string;
+  sectionBackground: SectionBackground;
+  orientation: SectionOrientation;
+  filteredRequests: Requests[];
+  collapse: boolean;
+  handleCollapse: () => void;
+  handlePinChange: (request: Requests, isPinned: boolean) => void;
+}
+
+function BoardSectionUI(props: BoardSectionUIProps) {
+  const {
+    sectionTitle,
+    sectionBackground = "light",
+    orientation = "vertical",
+    filteredRequests,
+    collapse,
+    handleCollapse,
+    handlePinChange,
+  } = props;
+
+  const smallScreen = useMediaQuery("(max-width: 595px)");
+
+  return (
+    <StyledBoardSection
+      $sectionBackground={sectionBackground}
+      $orientation={orientation}
+    >
+      <Stack
+        justifyContent={
+          orientation === "vertical" ? "space-between" : "flex-start"
+        }
+        alignItems="end"
+        gap={inube.spacing.s300}
+      >
+        <Stack
+          alignItems="end"
+          gap={inube.spacing.s100}
+          width={orientation === "vertical" ? "180px" : "auto"}
+          height={orientation === "vertical" ? "56px" : "auto"}
+        >
+          {orientation !== "vertical" && (
+            <StyledCollapseIcon
+              $collapse={collapse}
+              $disabledCollapse={filteredRequests.length === 0}
+              onClick={handleCollapse}
+            >
+              <Icon
+                icon={<MdOutlineChevronRight />}
+                disabled={filteredRequests.length === 0}
+                appearance="dark"
+                size="26px"
+                cursorHover
+              />
+            </StyledCollapseIcon>
+          )}
+          <Text
+            type={
+              orientation === "vertical" || smallScreen ? "title" : "headline"
+            }
+            size={
+              orientation === "vertical" || smallScreen ? "large" : "medium"
+            }
+          >
+            {sectionTitle}
+          </Text>
+        </Stack>
+        <Text type="title" size="medium">
+          {filteredRequests.length}
+        </Text>
+      </Stack>
+      {(collapse || orientation === "vertical") && (
+        <Stack
+          wrap="wrap"
+          alignItems="center"
+          direction={orientation === "vertical" ? "column" : "row"}
+          justifyContent={smallScreen ? "center" : "flex-start"}
+          gap={inube.spacing.s250}
+        >
+          {filteredRequests.map((request) => (
+            <SummaryCard
+              key={request.k_Prospe}
+              rad={request.k_Prospe}
+              date={capitalizeFirstLetter(
+                formatISODatetoCustomFormat(request.f_Prospe)
+              )}
+              name={request.nnasocia}
+              destination={request.k_Desdin}
+              value={request.v_Monto}
+              toDo={request.n_Descr_Tarea}
+              isPinned={request.isPinned}
+              onPinChange={(isPinned) => handlePinChange(request, isPinned)}
+              hasMessage={true}
+            />
+          ))}
+        </Stack>
+      )}
+    </StyledBoardSection>
+  );
+}
+
+export { BoardSectionUI };

--- a/src/components/layout/BoardSection/stories/props.ts
+++ b/src/components/layout/BoardSection/stories/props.ts
@@ -25,6 +25,10 @@ const props = {
     control: "array",
     description: "information about section summary cards",
   },
+  showPinnedOnly: {
+    control: "boolean",
+    description: "functionality to show pinned section information",
+  },
 };
 
 export { props };

--- a/src/pages/board/outlets/boardlayout/index.tsx
+++ b/src/pages/board/outlets/boardlayout/index.tsx
@@ -7,36 +7,85 @@ import { BoardLayoutUI } from "./interface";
 import { filterOptions } from "./config/select";
 import { IBoardData } from "./types";
 
-function BoardLayout() {
-  const [boardOrientation, setBoardOrientation] =
-    useState<SectionOrientation>("vertical");
-
+const useBoardOrientation = (initialOrientation: SectionOrientation) => {
+  const [boardOrientation, setBoardOrientation] = useState(initialOrientation);
   const handleOrientationChange = (orientation: SectionOrientation) => {
     setBoardOrientation(orientation);
   };
+  return { boardOrientation, handleOrientationChange };
+};
 
-  const [boardData, setBoardData] = useState<IBoardData>({
-    boardRequests: [],
-  });
+const useBoardData = () => {
+  const [boardData, setBoardData] = useState<IBoardData>({ boardRequests: [] });
+  const [filteredRequests, setFilteredRequests] = useState(
+    boardData.boardRequests
+  );
+  const [searchRequests, setSearchRequests] = useState("");
 
   useEffect(() => {
     getAll("requests")
       .then((data) => {
-        if (data !== null) {
+        if (data && Array.isArray(data)) {
           setBoardData({ boardRequests: data } as IBoardData);
+          setFilteredRequests(data);
         }
       })
       .catch((error) => {
         console.error("Error fetching requests data:", error.message);
       });
-  }, [boardData]);
+  }, []);
+
+  const handleFilterRequests = () => {
+    const results = boardData.boardRequests.filter(
+      (request) =>
+        request.nnasocia.toLowerCase().includes(searchRequests.toLowerCase()) ||
+        request.k_Prospe.toString().includes(searchRequests)
+    );
+    setFilteredRequests(results);
+  };
+
+  const handleSearchRequests = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchRequests(e.target.value);
+  };
+
+  return {
+    filteredRequests,
+    searchRequests,
+    handleFilterRequests,
+    handleSearchRequests,
+  };
+};
+
+const usePinnedRequests = () => {
+  const [showPinnedOnly, setShowPinnedOnly] = useState(false);
+  const handleShowPinnedOnly = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setShowPinnedOnly(e.target.checked);
+  };
+  return { showPinnedOnly, handleShowPinnedOnly };
+};
+
+function BoardLayout() {
+  const { boardOrientation, handleOrientationChange } =
+    useBoardOrientation("vertical");
+  const {
+    filteredRequests,
+    searchRequests,
+    handleFilterRequests,
+    handleSearchRequests,
+  } = useBoardData();
+  const { showPinnedOnly, handleShowPinnedOnly } = usePinnedRequests();
 
   return (
     <BoardLayoutUI
       filterOptions={filterOptions}
       boardOrientation={boardOrientation}
-      BoardRequests={boardData.boardRequests}
+      BoardRequests={filteredRequests}
+      searchRequests={searchRequests}
+      showPinnedOnly={showPinnedOnly}
+      handleShowPinnedOnly={handleShowPinnedOnly}
       onOrientationChange={handleOrientationChange}
+      handleSearchRequests={handleSearchRequests}
+      handleFilterRequests={handleFilterRequests}
     />
   );
 }

--- a/src/pages/board/outlets/boardlayout/interface.tsx
+++ b/src/pages/board/outlets/boardlayout/interface.tsx
@@ -23,7 +23,12 @@ interface BoardLayoutProps {
   filterOptions: FilterOption[];
   boardOrientation: SectionOrientation;
   BoardRequests: Requests[];
+  searchRequests: string;
+  showPinnedOnly: boolean;
+  handleShowPinnedOnly: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onOrientationChange: (orientation: SectionOrientation) => void;
+  handleSearchRequests: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFilterRequests: () => void;
 }
 
 function BoardLayoutUI(props: BoardLayoutProps) {
@@ -31,8 +36,14 @@ function BoardLayoutUI(props: BoardLayoutProps) {
     filterOptions,
     boardOrientation,
     BoardRequests,
+    searchRequests,
+    showPinnedOnly,
+    handleShowPinnedOnly,
     onOrientationChange,
+    handleSearchRequests,
+    handleFilterRequests,
   } = props;
+
   return (
     <Stack direction="column">
       <StyledInputsContainer>
@@ -45,9 +56,13 @@ function BoardLayoutUI(props: BoardLayoutProps) {
               size="compact"
               iconAfter={<MdSearch />}
               fullwidth
+              value={searchRequests}
+              onChange={handleSearchRequests}
             />
           </Stack>
-          <Button spacing="compact">Buscar</Button>
+          <Button spacing="compact" onClick={handleFilterRequests}>
+            Buscar
+          </Button>
         </Stack>
         <Stack width="100%" justifyContent="space-between" alignItems="center">
           <Stack width="500px">
@@ -68,7 +83,8 @@ function BoardLayoutUI(props: BoardLayoutProps) {
                 id="SeePinned"
                 name="SeePinned"
                 size="large"
-                onChange={() => {}}
+                checked={showPinnedOnly}
+                onChange={handleShowPinnedOnly}
               />
             </Stack>
             <Stack gap={inube.spacing.s100}>
@@ -99,6 +115,7 @@ function BoardLayoutUI(props: BoardLayoutProps) {
             sectionBackground={column.sectionBackground}
             orientation={boardOrientation}
             sectionInformation={BoardRequests}
+            showPinnedOnly={showPinnedOnly}
           />
         ))}
       </StyledBoardContainer>

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -11,6 +11,7 @@ interface Requests {
   nnasocia: string;
   n_Descr_Etapa: string;
   n_Descr_Tarea: string;
+  isPinned?: boolean;
 }
 
 type DmEtapasPrs =


### PR DESCRIPTION
In this task, the remaining functionalities managed by the board were configured, such as the textfield search engine, as well as the option to only show the requests that are pinned.