### PR TITLE
Create modal in CU030

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,3 +4,4 @@
   href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap"
   rel="stylesheet"
 />
+<div id="portal"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@auth0/auth0-react": "^2.2.4",
         "@inube/design-system": "^5.15.0",
+        "@types/yup": "^0.32.0",
+        "formik": "^2.4.6",
         "localforage": "^1.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
         "react-router-dom": "^6.22.3",
-        "styled-components": "^6.1.8"
+        "styled-components": "^6.1.8",
+        "yup": "^1.4.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.2.26",
@@ -9652,6 +9655,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -9943,6 +9955,15 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
+    },
+    "node_modules/@types/yup": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.32.0.tgz",
+      "integrity": "sha512-Gr2lllWTDxGVYHgWfL8szjdedERpNgm44L9BDL2cmcHG7Bfd6taEpiW3ayMFLaYvlJr/6bFXDJdh6L406AGlFg==",
+      "deprecated": "This is a stub types definition. yup provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "yup": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.5.0",
@@ -16376,6 +16397,38 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formik": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
+      "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/formik/node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -22732,6 +22785,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -25788,6 +25846,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -26213,6 +26276,11 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "node_modules/react-icons": {
       "version": "5.0.1",
@@ -28690,11 +28758,21 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
@@ -28742,6 +28820,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
@@ -30622,6 +30705,28 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
+      "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",
     "@inube/design-system": "^5.15.0",
+    "@types/yup": "^0.32.0",
+    "formik": "^2.4.6",
     "localforage": "^1.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-router-dom": "^6.22.3",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.8",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.2.26",

--- a/src/components/layout/ContainerSections/ContainerSections.stories.tsx
+++ b/src/components/layout/ContainerSections/ContainerSections.stories.tsx
@@ -1,12 +1,20 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { StoryFn, Meta, StoryObj } from "@storybook/react";
+import { BrowserRouter } from "react-router-dom";
 
 import { ContainerSections } from ".";
 
 type Story = StoryObj<typeof ContainerSections>;
 
 const meta: Meta<typeof ContainerSections> = {
-  title: "layouts/ContainerSections",
+  title: "components/layouts/ContainerSections",
   component: ContainerSections,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
 };
 
 export const Default: Story = {

--- a/src/components/layout/ContainerSections/index.tsx
+++ b/src/components/layout/ContainerSections/index.tsx
@@ -14,14 +14,14 @@ interface IContainerSectionsProps {
 
 export const ContainerSections = (props: IContainerSectionsProps) => {
   const { children } = props;
-  const [showRejectModal, setShowRejectModal] = useState(false);
+  const [showRejectionModal, setShowRejectionModal] = useState(false);
 
   const handleToggleRejectModal = () => {
-    setShowRejectModal(!showRejectModal);
+    setShowRejectionModal(!showRejectionModal);
   };
 
   const handleSubmitRejectModal = () => {
-    setShowRejectModal(!showRejectModal);
+    setShowRejectionModal(!showRejectionModal);
   };
 
   const navigation = useNavigate();
@@ -61,7 +61,7 @@ export const ContainerSections = (props: IContainerSectionsProps) => {
         </Stack>
         <Stack direction="column">{children}</Stack>
       </Stack>
-      {showRejectModal && (
+      {showRejectionModal && (
         <TextAreaModal
           title="Rechazar"
           buttonText="Confirmar"

--- a/src/components/layout/ContainerSections/index.tsx
+++ b/src/components/layout/ContainerSections/index.tsx
@@ -65,7 +65,7 @@ export const ContainerSections = (props: IContainerSectionsProps) => {
         <TextAreaModal
           title="Rechazar"
           buttonText="Confirmar"
-          inputLabel="Motivo del Rechazo"
+          inputLabel="Motivo del rechazo."
           inputPlaceholder="Describa el motivo del rechazo."
           onCloseModal={handleToggleRejectModal}
           onSubmit={handleSubmitRejectModal}

--- a/src/components/layout/ContainerSections/index.tsx
+++ b/src/components/layout/ContainerSections/index.tsx
@@ -1,6 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { MdArrowBack } from "react-icons/md";
 import { Button, Stack, inube } from "@inube/design-system";
+import { useState } from "react";
+
+import { TextAreaModal } from "@components/modals/TextAreaModal";
 
 import { configButtons } from "./config";
 import { StyledHorizontalDivider } from "./styles";
@@ -11,40 +14,63 @@ interface IContainerSectionsProps {
 
 export const ContainerSections = (props: IContainerSectionsProps) => {
   const { children } = props;
+  const [showRejectModal, setShowRejectModal] = useState(false);
+
+  const handleToggleRejectModal = () => {
+    setShowRejectModal(!showRejectModal);
+  };
+
+  const handleSubmitRejectModal = () => {
+    setShowRejectModal(!showRejectModal);
+  };
 
   const navigation = useNavigate();
 
   return (
-    <Stack width="-webkit-fill-available" direction="column">
-      <Stack direction="column">
-        <Stack justifyContent="start" margin="s0 s0 s250">
-          <Button
-            spacing="compact"
-            variant="none"
-            iconBefore={<MdArrowBack />}
-            onClick={() => navigation(-1)}
-          >
-            Volver
-          </Button>
-        </Stack>
-        <Stack justifyContent="end" gap={inube.spacing.s200}>
-          <Stack gap={inube.spacing.s400}>
-            <Button>{configButtons.buttons.buttonOne.label}</Button>
-            <Button>{configButtons.buttons.buttonTwo.label}</Button>
-            <Button>{configButtons.buttons.buttonTree.label}</Button>
-          </Stack>
-          <StyledHorizontalDivider />
-          <Stack gap={inube.spacing.s200}>
-            <Button variant="outlined">
-              {configButtons.buttonsOutlined.buttonOne.label}
-            </Button>
-            <Button variant="outlined">
-              {configButtons.buttonsOutlined.buttonTwo.label}
+    <>
+      <Stack width="-webkit-fill-available" direction="column">
+        <Stack direction="column">
+          <Stack justifyContent="start" margin="s0 s0 s250">
+            <Button
+              spacing="compact"
+              variant="none"
+              iconBefore={<MdArrowBack />}
+              onClick={() => navigation(-1)}
+            >
+              Volver
             </Button>
           </Stack>
+          <Stack justifyContent="end" gap={inube.spacing.s200}>
+            <Stack gap={inube.spacing.s400}>
+              <Button onClick={handleToggleRejectModal}>
+                {configButtons.buttons.buttonOne.label}
+              </Button>
+              <Button>{configButtons.buttons.buttonTwo.label}</Button>
+              <Button>{configButtons.buttons.buttonTree.label}</Button>
+            </Stack>
+            <StyledHorizontalDivider />
+            <Stack gap={inube.spacing.s200}>
+              <Button variant="outlined">
+                {configButtons.buttonsOutlined.buttonOne.label}
+              </Button>
+              <Button variant="outlined">
+                {configButtons.buttonsOutlined.buttonTwo.label}
+              </Button>
+            </Stack>
+          </Stack>
         </Stack>
+        <Stack direction="column">{children}</Stack>
       </Stack>
-      <Stack direction="column">{children}</Stack>
-    </Stack>
+      {showRejectModal && (
+        <TextAreaModal
+          title="Rechazar"
+          buttonText="Confirmar"
+          inputLabel="Motivo del Rechazo"
+          inputPlaceholder="Describa el motivo del rechazo."
+          onCloseModal={handleToggleRejectModal}
+          onSubmit={handleSubmitRejectModal}
+        />
+      )}
+    </>
   );
 };

--- a/src/components/modals/TextAreaModal/index.tsx
+++ b/src/components/modals/TextAreaModal/index.tsx
@@ -1,0 +1,109 @@
+import {
+  Stack,
+  useMediaQuery,
+  Blanket,
+  Text,
+  Button,
+  inube,
+  Textarea,
+} from "@inube/design-system";
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import { useState } from "react";
+
+import { StyledModal } from "./styles";
+
+export interface TextAreaModalProps {
+  title: string;
+  buttonText: string;
+  inputLabel: string;
+  inputPlaceholder: string;
+  maxLength?: number;
+  portalId?: string;
+  onSubmit?: () => void;
+  onCloseModal?: () => void;
+}
+
+export function TextAreaModal(props: TextAreaModalProps) {
+  const {
+    title,
+    buttonText,
+    inputLabel,
+    inputPlaceholder,
+    maxLength = 200,
+    portalId = "portal",
+    onSubmit,
+    onCloseModal,
+  } = props;
+  const [input, setInput] = useState({ value: "", status: "" });
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput({ value: e.target.value, status: "pending" });
+    return;
+  };
+
+  const onFocus = () => {
+    if (input.status === "invalid") {
+      return setInput({ ...input, status: "invalid" });
+    }
+    setInput({ ...input, status: "pending" });
+  };
+
+  const onBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > maxLength) {
+      setInput({ ...input, status: "invalid" });
+    } else setInput({ ...input, status: "valid" });
+  };
+  const message =
+    input.status === "valid"
+      ? "El campo ha sido validado exitosamente"
+      : "El número de caracteres es demasiado largo";
+
+  const isMobile = useMediaQuery("(max-width: 700px)");
+  const node = document.getElementById(portalId);
+
+  if (node === null) {
+    throw new Error(
+      "The portal node is not defined. This can occur when the specific node used to render the portal has not been defined correctly."
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal $smallScreen={isMobile}>
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small">
+            {title}
+          </Text>
+          <Stack gap={inube.spacing.s100}>
+            <Text>Cerrar</Text>
+            <MdClear size={24} cursor="pointer" onClick={onCloseModal} />
+          </Stack>
+        </Stack>
+        <Textarea
+          label={inputLabel}
+          placeholder={inputPlaceholder}
+          value={input.value}
+          status={input.status}
+          maxLength={maxLength}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          message={message}
+          fullwidth
+        />
+        <Stack justifyContent="flex-end">
+          <Button
+            onClick={onSubmit}
+            disabled={
+              input.value.length > maxLength || input.value.length === 0
+            }
+          >
+            {buttonText}
+          </Button>
+        </Stack>
+      </StyledModal>
+    </Blanket>,
+    node
+  );
+}

--- a/src/components/modals/TextAreaModal/stories/TextAreaModal.stories.tsx
+++ b/src/components/modals/TextAreaModal/stories/TextAreaModal.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { Button } from "@inube/design-system";
+
+import { TextAreaModal, TextAreaModalProps } from "..";
+import { props } from "./props";
+
+const story: Meta<typeof TextAreaModal> = {
+  component: TextAreaModal,
+  title: "components/modals/TextAreaModal",
+  argTypes: props,
+};
+
+const DefaultTemplate: StoryFn<TextAreaModalProps> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShowModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <Button onClick={handleShowModal}>Open Modal</Button>
+      {showModal && <TextAreaModal {...args} onCloseModal={handleShowModal} />}
+    </>
+  );
+};
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  title: "Default Title",
+  buttonText: "Submit",
+  inputLabel: "Input Label",
+  inputPlaceholder: "Type something...",
+  maxLength: 200,
+  portalId: "portal",
+};
+
+export default story;

--- a/src/components/modals/TextAreaModal/stories/props.ts
+++ b/src/components/modals/TextAreaModal/stories/props.ts
@@ -1,0 +1,36 @@
+const props = {
+  title: {
+    control: "text",
+    description: "Title of the modal",
+  },
+  buttonText: {
+    control: "text",
+    description: "Text for the submit button",
+  },
+  inputLabel: {
+    control: "text",
+    description: "Label for the textarea input",
+  },
+  inputPlaceholder: {
+    control: "text",
+    description: "Placeholder for the textarea input",
+  },
+  maxLength: {
+    control: "number",
+    description: "Maximum length of the textarea input",
+  },
+  portalId: {
+    control: "text",
+    description: "ID of the portal node",
+  },
+  onSubmit: {
+    action: "submitted",
+    description: "Function called when the form is submitted",
+  },
+  onCloseModal: {
+    action: "closed",
+    description: "Function called when the modal is closed",
+  },
+};
+
+export { props };

--- a/src/components/modals/TextAreaModal/styles.ts
+++ b/src/components/modals/TextAreaModal/styles.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import { inube } from "@inube/design-system";
+
+interface IStyledModal {
+  $smallScreen: boolean;
+  theme?: typeof inube;
+}
+
+const StyledModal = styled.div<IStyledModal>`
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) =>
+    theme.color?.surface?.light?.clear || inube.color.surface.light.clear};
+  width: ${({ $smallScreen }) => ($smallScreen ? "280px" : "500px")};
+  padding: ${({ $smallScreen }) =>
+    $smallScreen ? inube.spacing.s200 : inube.spacing.s300};
+  gap: ${({ $smallScreen }) =>
+    $smallScreen ? inube.spacing.s200 : inube.spacing.s300};
+  border-radius: ${inube.spacing.s100};
+`;
+
+export { StyledModal };


### PR DESCRIPTION
The modal that appears in operation CU030 was carried out, which is when the reject button is clicked in the financialReporting outlet.

![image](https://github.com/selsa-inube/crediboard/assets/87447257/71a83552-f06b-4c49-b43d-cb4f78071a52)

points to consider:

- The modal component was configured to be general and accept any type of configuration related to the textarea

- The textarea component of the current version of the design-system library does not allow removing the resize

- The component receives a maxLength, which is the characters maximum that the component receives, which cannot be removed, so the modal was assigned to have this value be 200 characters by default.

- when the number of current characters in the textarea is equal to 0 or is greater than the maxLength the confirm button becomes disabled