### PR TITLE
correct `key` error in `trace` cb-104

### DIFF
--- a/src/pages/board/outlets/financialReporting/management/index.tsx
+++ b/src/pages/board/outlets/financialReporting/management/index.tsx
@@ -35,7 +35,7 @@ export const Management = () => {
     get("trace").then((data) => {
       const trace = (data as MessageTypedos[])[0].trace;
       const message: MessageType[] = trace.map((trace) => ({
-        id: trace.credit_request_id,
+        id: trace.trace_id,
         type: "sent",
         timestamp: trace.execution_date,
         text: trace.justification,


### PR DESCRIPTION
fix the error in the array created, with the data consumed from the trace identity, which generated an error in the console because the `key` attribute was repeated
![image](https://github.com/user-attachments/assets/d30e941d-7f94-41bf-9ebe-186c2c4e4b53)
