### PR TITLE
At/cb229/adjust textfield

### DIFF
--- a/src/pages/board/outlets/boardlayout/interface.tsx
+++ b/src/pages/board/outlets/boardlayout/interface.tsx
@@ -106,7 +106,7 @@ function BoardLayoutUI(props: BoardLayoutProps) {
           <Stack
             justifyContent="space-between"
             width={isMobile ? "100%" : "auto"}
-            margin={isMobile ? "s100 s0" : "0px 0px 24px "}
+            margin={isMobile ? "s100 s0" : "0px 0px 24px"}
           >
             <StyledSearch
               ref={stackRef}

--- a/src/pages/board/outlets/boardlayout/interface.tsx
+++ b/src/pages/board/outlets/boardlayout/interface.tsx
@@ -106,7 +106,7 @@ function BoardLayoutUI(props: BoardLayoutProps) {
           <Stack
             justifyContent="space-between"
             width={isMobile ? "100%" : "auto"}
-            margin={isMobile ? "s100 s0" : "auto"}
+            margin={isMobile ? "s100 s0" : "0px 0px 24px "}
           >
             <StyledSearch
               ref={stackRef}
@@ -120,12 +120,13 @@ function BoardLayoutUI(props: BoardLayoutProps) {
                 <Textfield
                   id="SearchCards"
                   name="SearchCards"
-                  placeholder={isMobile ? "" : "Buscar..."}
+                  placeholder={isMobile ? "" : "Nombre o No. de radicado"}
                   size="compact"
                   iconAfter={<MdSearch />}
                   value={searchRequestValue}
                   onChange={handleSearchRequestsValue}
                   fullwidth
+                  label="Búsqueda"
                 />
               </Stack>
             </StyledSearch>
@@ -154,7 +155,7 @@ function BoardLayoutUI(props: BoardLayoutProps) {
             alignItems="center"
             margin={isMobile ? "s200 s0" : "auto"}
           >
-            <Stack width={isMobile ? "100%" : "500px"}>
+            <Stack width={isMobile ? "100%" : "480px"}>
               <Selectcheck {...selectProps} />
             </Stack>
             <Stack gap="16px">

--- a/src/pages/board/outlets/boardlayout/styles.ts
+++ b/src/pages/board/outlets/boardlayout/styles.ts
@@ -16,7 +16,6 @@ interface IStyledSearch {
 }
 
 const StyledInputsContainer = styled.div<IStyledInputsContainer>`
-  display: ${({ $isMobile }) => ($isMobile ? "block" : "flex")};
   flex-direction: column;
   align-items: center;
   padding-top: ${({ $isMobile }) => ($isMobile ? "12px" : "32px")};


### PR DESCRIPTION
ajustar el componente Textfield de la pagina principal para que este alineado a la izquierda de su contenedor, que lleve un label y modificar su placeholder actual al que se muestra en la imagen
![image](https://github.com/user-attachments/assets/93801c98-3d03-40cd-a5bf-0315b7b92ebf)
